### PR TITLE
Updated plugin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In your `serverless.yml` file, reference the handler function from above to prov
 To serve binary content make sure that you setup the plugin in your serverless.yml like so:
 
     plugins:
-      - serverless-aws-static-file-handler/plugins/BinaryMediaTypes
+      - serverless-aws-static-file-handler/src/plugins/BinaryMediaTypes
 
     custom:
       apiGateway:


### PR DESCRIPTION
## What did you implement:

Closes #32 

The source code structure changed and so did the plugin path.

## How did you implement it:
Added `src` to the plugin path.

## How can we verify it:

If using serverless offline, start a service that uses this plugin and it will not report the plugin error.

Examples:
* `$ sls offline start --stage development`

## Todos:

- [ ] Update tests (?)
