### PR TITLE
fix: This plugin now works properly with Serverless 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ examples/basic/.serverless
 /todo.md
 
 .serverless/
+
+.DS_Store

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -11,9 +11,9 @@
     "reset": "rm -rfd ./node_modules/ && npm i && npm run deploy"
   },
   "devDependencies": {
-    "serverless": "^1.46.1"
+    "serverless": "^2.52.1"
   },
   "dependencies": {
-    "serverless-aws-static-file-handler": "=2.0.8"
+    "serverless-aws-static-file-handler": "file://../../serverless-aws-static-file-handler-0.0.0.tgz"
   }
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -14,6 +14,6 @@
     "serverless": "^2.52.1"
   },
   "dependencies": {
-    "serverless-aws-static-file-handler": "file://../../serverless-aws-static-file-handler-0.0.0.tgz"
+    "serverless-aws-static-file-handler": "beta"
   }
 }

--- a/examples/basic/serverless.yml
+++ b/examples/basic/serverless.yml
@@ -13,6 +13,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs14.x
+  lambdaHashingVersion: 20201221
 
 functions:
   html:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "serverless": "^2.46.0",
     "sinon": "^10.0.0"
   },
+  "peerDependencies": {
+    "serverless": "^2.46.0 || ^1.46.1"
+  },
   "engines": {
     "node": ">=10"
   },

--- a/src/plugins/BinaryMediaTypes.js
+++ b/src/plugins/BinaryMediaTypes.js
@@ -10,11 +10,6 @@ class BinaryMediaTypes {
     this.serverless = serverless
     this.options = options
     this.provider = this.serverless.getProvider("aws")
-    this.commands = {
-      deploy: {
-        lifecycleEvents: ["resources"],
-      },
-    }
     this.hooks = {
       "package:compileEvents": this.packageCompileEvents.bind(this),
     }
@@ -65,6 +60,7 @@ class BinaryMediaTypes {
   }
 
   packageCompileEvents() {
+    this.log("Preparing to add binary media types (package:compileEvents)...")
     const restApi = this.getRestApi()
     this.addBinaryMediaTypes(restApi)
   }

--- a/src/test/BinaryMediaTypes.js
+++ b/src/test/BinaryMediaTypes.js
@@ -78,9 +78,9 @@ describe("BinaryMediaTypes", function () {
       p.serverless.service.provider.compiledCloudFormationTemplate.Resources = []
       const hook = getHook(p)
       expect(hook).to.not.throw()
-      expect(logSpy.callCount).to.equal(1)
+      expect(logSpy.callCount).to.equal(2)
       expect(
-        logSpy.calledOnceWithExactly(
+        logSpy.calledWithExactly(
           sinon.match(
             /Amazon API Gateway RestApi resource not found. No BinaryMediaTypes will be added.$/
           )


### PR DESCRIPTION
* Before this fix the plugin was silently failing during the deploy command with serverless v2. This corrects that issue by no longer registering deploy as a command
* Tested examples/basic w/ serverless@2.52.1

fixes #92