### PR TITLE
fix: support for serverless framework v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           flag-name: nodejs-${{ matrix.node }}
           parallel: true
 
-  finish_unit_tests:
+  update_code_coverage:
     needs: unit_tests
     runs-on: ubuntu-20.04
     steps:
@@ -78,11 +78,14 @@ jobs:
 
       #- name: debug deploy_package
       #  uses: actions/bin/debug@master
-
-      - name: run end-to-end deploy test
+      - name: preapre to run end-to-end deploy test
         env:
           AWS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          serverless config credentials --provider aws --key $AWS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY
+
+      - name: run end-to-end deploy test
         run: |
           cd "$GITHUB_WORKSPACE/examples/basic"
           npm i
@@ -118,9 +121,6 @@ jobs:
       - name: destroy serverless stack
         # Run this step even if the prior one failed (to clean up)
         if: ${{ always() }}
-        env:
-          AWS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           cd "$GITHUB_WORKSPACE/examples/basic"
           npm run destroy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [main]
+    branches: [main, beta, next]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE/examples/basic"
           npm i
-          serverless config credentials --provider aws --key $AWS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY
+          serverless config credentials --provider aws --key $AWS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY --profile serverless --overwrite
 
       - name: run end-to-end deploy and test endpoints
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE/examples/basic"
           npm i
-          serverless config credentials --provider aws --key $AWS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY --profile serverless --overwrite
+          ./node_modules/.bin/serverless config credentials --provider aws --key $AWS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY --profile serverless --overwrite
 
       - name: run end-to-end deploy and test endpoints
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,17 +78,18 @@ jobs:
 
       #- name: debug deploy_package
       #  uses: actions/bin/debug@master
-      - name: preapre to run end-to-end deploy test
+      - name: prepare to run end-to-end deploy test
         env:
           AWS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          serverless config credentials --provider aws --key $AWS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY
-
-      - name: run end-to-end deploy test
-        run: |
           cd "$GITHUB_WORKSPACE/examples/basic"
           npm i
+          serverless config credentials --provider aws --key $AWS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY
+
+      - name: run end-to-end deploy and test endpoints
+        run: |
+          cd "$GITHUB_WORKSPACE/examples/basic"
           npm run deploy
           # get the APIG endpoint URL:
           APIG_URL=$(./node_modules/.bin/serverless info --aws-profile serverless | sed -nr 's#^.*(https://.+/dev)/png$#\1#p')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,22 +102,35 @@ jobs:
                 echo "path not specified"
                 return 1
               fi
+              EXPECT_CODE=$2
+              if [[ -e "$EXPECT_CODE" ]]; then
+                EXPECT_CODE=200
+              fi
+
               HTTP_CODE=$(curl -s -w '%{http_code}' --compressed --output /dev/null "$APIG_URL/$URL_PATH")
-              if [[ "$HTTP_CODE" = "200" ]]; then
+              if [[ "$HTTP_CODE" = "$EXPECT_CODE" ]]; then
                 echo "/$URL_PATH succeeded"
               else
-                echo "/$URL_PATH failed with code $HTTP_CODE"
+                echo "FAILURE: Expected /$URL_PATH to have code $EXPECT_CODE but it was $HTTP_CODE"
                 exit $HTTP_CODE
               fi
             }
 
+          # 200; these all should succeed
           TEST_HTTP png
-
           TEST_HTTP jpg
-
           TEST_HTTP binary/glyphicons-halflings-regular.woff2
-
           TEST_HTTP binary/subdir/png.png
+
+          # 403
+          TEST_HTTP "ff404.png" 403
+          TEST_HTTP "jpeg404.jpg" 403
+          TEST_HTTP "subdir404/ff.png" 403
+          TEST_HTTP "subdir/ff404.png" 403
+
+          # 404
+          TEST_HTTP "binary/404-glyphicons-halflings-regular.woff2" 404
+          TEST_HTTP "binary/subdir/404-png.png" 404
 
       - name: destroy serverless stack
         # Run this step even if the prior one failed (to clean up)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,18 +98,18 @@ jobs:
           function TEST_HTTP ()
             {
               URL_PATH=$1
-              if [[ -e "$URL_PATH" ]]; then
+              if [[ -z "$URL_PATH" ]]; then
                 echo "path not specified"
                 return 1
               fi
               EXPECT_CODE=$2
-              if [[ -e "$EXPECT_CODE" ]]; then
+              if [[ -z "$EXPECT_CODE" ]]; then
                 EXPECT_CODE=200
               fi
 
               HTTP_CODE=$(curl -s -w '%{http_code}' --compressed --output /dev/null "$APIG_URL/$URL_PATH")
               if [[ "$HTTP_CODE" = "$EXPECT_CODE" ]]; then
-                echo "/$URL_PATH succeeded"
+                echo "/$URL_PATH succeeded (returned expected code $HTTP_CODE)"
               else
                 echo "FAILURE: Expected /$URL_PATH to have code $EXPECT_CODE but it was $HTTP_CODE"
                 exit $HTTP_CODE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: "npm"
 
       - name: install dependencies
         run: |
@@ -78,6 +79,12 @@ jobs:
 
       #- name: debug deploy_package
       #  uses: actions/bin/debug@master
+      - name: build plugin locally
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          npm i
+          npm pack
+
       - name: prepare to run end-to-end deploy test
         env:
           AWS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
@@ -85,6 +92,8 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE/examples/basic"
           npm i
+          # now update to use the local plugin built above
+          npm install --save file://../../serverless-aws-static-file-handler-0.0.0.tgz
           ./node_modules/.bin/serverless config credentials --provider aws --key $AWS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY --profile serverless --overwrite
 
       - name: run end-to-end deploy and test endpoints

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           npm run lint
 
-  build_and_test:
+  unit_tests:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -55,8 +55,8 @@ jobs:
           flag-name: nodejs-${{ matrix.node }}
           parallel: true
 
-  finish_tests:
-    needs: build_and_test
+  finish_unit_tests:
+    needs: unit_tests
     runs-on: ubuntu-20.04
     steps:
       - name: Coveralls Finished
@@ -65,8 +65,68 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
 
+  e2e_tests:
+    needs: unit_tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Use Node.js v12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: v12.x
+
+      #- name: debug deploy_package
+      #  uses: actions/bin/debug@master
+
+      - name: run end-to-end deploy test
+        env:
+          AWS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          cd "$GITHUB_WORKSPACE/examples/basic"
+          npm i
+          npm run deploy
+          # get the APIG endpoint URL:
+          APIG_URL=$(./node_modules/.bin/serverless info --aws-profile serverless | sed -nr 's#^.*(https://.+/dev)/png$#\1#p')
+
+          # CURL to some known good endpoints expecting 200:
+          function TEST_HTTP ()
+            {
+              URL_PATH=$1
+              if [[ -e "$URL_PATH" ]]; then
+                echo "path not specified"
+                return 1
+              fi
+              HTTP_CODE=$(curl -s -w '%{http_code}' --compressed --output /dev/null "$APIG_URL/$URL_PATH")
+              if [[ "$HTTP_CODE" = "200" ]]; then
+                echo "/$URL_PATH succeeded"
+              else
+                echo "/$URL_PATH failed with code $HTTP_CODE"
+                exit $HTTP_CODE
+              fi
+            }
+
+          TEST_HTTP png
+
+          TEST_HTTP jpg
+
+          TEST_HTTP binary/glyphicons-halflings-regular.woff2
+
+          TEST_HTTP binary/subdir/png.png
+
+      - name: destroy serverless stack
+        # Run this step even if the prior one failed (to clean up)
+        if: ${{ always() }}
+        env:
+          AWS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          cd "$GITHUB_WORKSPACE/examples/basic"
+          npm run destroy
+
   deploy_package:
-    needs: finish_tests
+    needs: e2e_tests
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ examples/basic/.serverless
 /todo.md
 
 .serverless/
+
+.DS_Store

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -11,9 +11,9 @@
     "reset": "rm -rfd ./node_modules/ && npm i && npm run deploy"
   },
   "devDependencies": {
-    "serverless": "^1.46.1"
+    "serverless": "^2.52.1"
   },
   "dependencies": {
-    "serverless-aws-static-file-handler": "=2.0.8"
+    "serverless-aws-static-file-handler": "file://../../serverless-aws-static-file-handler-0.0.0.tgz"
   }
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -14,6 +14,6 @@
     "serverless": "^2.52.1"
   },
   "dependencies": {
-    "serverless-aws-static-file-handler": "file://../../serverless-aws-static-file-handler-0.0.0.tgz"
+    "serverless-aws-static-file-handler": "beta"
   }
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -14,6 +14,6 @@
     "serverless": "^2.52.1"
   },
   "dependencies": {
-    "serverless-aws-static-file-handler": "beta"
+    "serverless-aws-static-file-handler": ">=3.0.2-beta.1"
   }
 }

--- a/examples/basic/serverless.yml
+++ b/examples/basic/serverless.yml
@@ -13,6 +13,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs14.x
+  lambdaHashingVersion: 20201221
 
 functions:
   html:

--- a/examples/serverless-offline/package.json
+++ b/examples/serverless-offline/package.json
@@ -10,10 +10,10 @@
     "reset": "rm -rfd ./node_modules/ && npm i && npm run deploy"
   },
   "devDependencies": {
-    "serverless": "^1.46.1",
+    "serverless": "^2.52.1",
     "serverless-offline": "^7.0.0"
   },
   "dependencies": {
-    "serverless-aws-static-file-handler": "beta"
+    "serverless-aws-static-file-handler": ">=3.0.2-beta.1"
   }
 }

--- a/examples/serverless-offline/package.json
+++ b/examples/serverless-offline/package.json
@@ -14,6 +14,6 @@
     "serverless-offline": "^7.0.0"
   },
   "dependencies": {
-    "serverless-aws-static-file-handler": "=2.0.8"
+    "serverless-aws-static-file-handler": "beta"
   }
 }

--- a/examples/serverless-offline/serverless.yml
+++ b/examples/serverless-offline/serverless.yml
@@ -14,6 +14,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs14.x
+  lambdaHashingVersion: 20201221
 
 functions:
   html:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "serverless": "^2.46.0",
     "sinon": "^10.0.0"
   },
+  "peerDependencies": {
+    "serverless": "^2.46.0 || ^1.46.1"
+  },
   "engines": {
     "node": ">=10"
   },

--- a/src/plugins/BinaryMediaTypes.js
+++ b/src/plugins/BinaryMediaTypes.js
@@ -10,11 +10,6 @@ class BinaryMediaTypes {
     this.serverless = serverless
     this.options = options
     this.provider = this.serverless.getProvider("aws")
-    this.commands = {
-      deploy: {
-        lifecycleEvents: ["resources"],
-      },
-    }
     this.hooks = {
       "package:compileEvents": this.packageCompileEvents.bind(this),
     }
@@ -65,6 +60,7 @@ class BinaryMediaTypes {
   }
 
   packageCompileEvents() {
+    this.log("Preparing to add binary media types (package:compileEvents)...")
     const restApi = this.getRestApi()
     this.addBinaryMediaTypes(restApi)
   }

--- a/src/test/BinaryMediaTypes.js
+++ b/src/test/BinaryMediaTypes.js
@@ -78,9 +78,9 @@ describe("BinaryMediaTypes", function () {
       p.serverless.service.provider.compiledCloudFormationTemplate.Resources = []
       const hook = getHook(p)
       expect(hook).to.not.throw()
-      expect(logSpy.callCount).to.equal(1)
+      expect(logSpy.callCount).to.equal(2)
       expect(
-        logSpy.calledOnceWithExactly(
+        logSpy.calledWithExactly(
           sinon.match(
             /Amazon API Gateway RestApi resource not found. No BinaryMediaTypes will be added.$/
           )


### PR DESCRIPTION
* update plugin implementation work with serverless v2 by not registering an explicit deploy command (🤦‍♂️, fixes #92)
* continues to work with serverless framework v1.x
* update examples to use serverless framework v2 and to pull the latest version of the plugin
* added end-to-end test to validate successful deploy

