### PR TITLE
chore(build): check for missing secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,16 @@ jobs:
           AWS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
+          # When dependabot or other forks trigger a workflow these secrets won't be passed (at leat not without the right setup). This makes it easier to spot it in output.
+          if [[ -z "$AWS_KEY_ID" ]]; then
+            echo "AWS_KEY_ID not specified (note that Secrets are not passed to workflows that are triggered by a pull request from a fork: https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow)"
+            return 1
+          fi
+          if [[ -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+            echo "AWS_SECRET_ACCESS_KEY not specified (note that Secrets are not passed to workflows that are triggered by a pull request from a fork: https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow)"
+            return 1
+          fi
+
           cd "$GITHUB_WORKSPACE/examples/basic"
           npm i
           # now update to use the local plugin built above


### PR DESCRIPTION
When dependabot or other forks trigger a workflow these secrets won't be passed (at least not without the right setup). This makes it easier to spot it in output: https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow

Happened in [this run](https://github.com/activescott/serverless-aws-static-file-handler/runs/3330594427?check_suite_focus=true#step:5:76)