### PR TITLE
chore(build): enable CI to deploy concurrently: one for deploying from push to deploy branches (main, beta, next) and one for PRs for those branches back to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,9 @@ jobs:
       # For more information on serverless stages:
       # - https://www.serverless.com/framework/docs/providers/aws/cli-reference/deploy/
       # - https://www.serverless.com/framework/docs/providers/aws/guide/deploying#tips
-      SERVERLESS_STAGE: ${{ github.event_name }}
+      # github.run_id: A unique number for each run within a repository. This number does not change if you re-run the workflow run. https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
+      # github format: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#format
+      SERVERLESS_STAGE: ${{ github.event_name == "pull_request" && format('pr{0}', github.job_id) || format('push{0}', github.job_id) }}
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
           ./node_modules/.bin/serverless deploy --aws-profile serverless --stage $SERVERLESS_STAGE
 
           # get the APIG endpoint URL:
-          APIG_URL=$(./node_modules/.bin/serverless info --aws-profile serverless --stage $SERVERLESS_STAGE | sed -nr 's#^.*(https://.+/dev)/png$#\1#p')
+          APIG_URL=$(./node_modules/.bin/serverless info --aws-profile serverless --stage $SERVERLESS_STAGE | sed -nr "s#^.*(https://.+/$SERVERLESS_STAGE)/png\$#\1#p")
           echo "Discovered APIG_URL: $APIG_URL"
 
           # CURL to some known good endpoints expecting 200:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE/examples/basic"
           echo "Destroying serverless stage $SERVERLESS_STAGE"
-          APIG_URL=$(./node_modules/.bin/serverless remove --aws-profile serverless --stage $SERVERLESS_STAGE
+          ./node_modules/.bin/serverless remove --aws-profile serverless --stage $SERVERLESS_STAGE
 
   publish_package:
     needs: [e2e_tests, unit_tests]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,13 @@
 name: build
 
+# We want pushes to main, beta, and next to trigger a publish to npm for the corresponding npm dist-tag.
+# NOTE: semantic-release detects pull requests and won't deploy on them so we don't have to deal with that complexity here.
+# Any pull request should run all tests.
+# NOTE: e2e tests use shared resource (AWS) and if they run concurrently they step on one another and cause errors.
+#       This can happen for beta & next branches if a PR targeting main also exists for them. There is some logic in e2e_tests job to mitigate this.
 on:
   push:
-    branches: [beta, next]
+    branches: [main, beta, next]
   pull_request:
     branches: [main]
 
@@ -69,6 +74,12 @@ jobs:
   e2e_tests:
     needs: unit_tests
     runs-on: ubuntu-20.04
+    env:
+      # e2e tests use a shared resource in AWS. Since we trigger on both a push to beta/next and a PR with destination branch of main, a PR against beta/next will cause them to run concurrently and causes errors. To prevent this contention we use a serverless stage.
+      # For more information on serverless stages:
+      # - https://www.serverless.com/framework/docs/providers/aws/cli-reference/deploy/
+      # - https://www.serverless.com/framework/docs/providers/aws/guide/deploying#tips
+      SERVERLESS_STAGE: ${{ github.event_name }}
     steps:
       - uses: actions/checkout@v1
 
@@ -109,7 +120,8 @@ jobs:
           cd "$GITHUB_WORKSPACE/examples/basic"
           npm run deploy
           # get the APIG endpoint URL:
-          APIG_URL=$(./node_modules/.bin/serverless info --aws-profile serverless | sed -nr 's#^.*(https://.+/dev)/png$#\1#p')
+          echo "Deploying serverless stage $SERVERLESS_STAGE"
+          APIG_URL=$(./node_modules/.bin/serverless info --aws-profile serverless --stage $SERVERLESS_STAGE | sed -nr 's#^.*(https://.+/dev)/png$#\1#p')
 
           # CURL to some known good endpoints expecting 200:
           function TEST_HTTP ()
@@ -154,10 +166,11 @@ jobs:
         if: ${{ always() }}
         run: |
           cd "$GITHUB_WORKSPACE/examples/basic"
-          npm run destroy
+          echo "Destroying serverless stage $SERVERLESS_STAGE"
+          APIG_URL=$(./node_modules/.bin/serverless remove --aws-profile serverless --stage $SERVERLESS_STAGE
 
   publish_package:
-    needs: e2e_tests
+    needs: [e2e_tests, unit_tests]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       # - https://www.serverless.com/framework/docs/providers/aws/guide/deploying#tips
       # github.run_id: A unique number for each run within a repository. This number does not change if you re-run the workflow run. https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
       # github format: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#format
-      SERVERLESS_STAGE: ${{ github.event_name == 'pull_request' && format('pr{0}', github.job_id) || format('push{0}', github.job_id) }}
+      SERVERLESS_STAGE: ${{ github.event_name == 'pull_request' && format('pr{0}', github.run_id) || format('push{0}', github.run_id) }}
     steps:
       - uses: actions/checkout@v1
 
@@ -120,10 +120,12 @@ jobs:
       - name: run end-to-end and test endpoints
         run: |
           cd "$GITHUB_WORKSPACE/examples/basic"
-          npm run deploy
-          # get the APIG endpoint URL:
           echo "Deploying serverless stage $SERVERLESS_STAGE"
+          ./node_modules/.bin/serverless deploy --aws-profile serverless --stage $SERVERLESS_STAGE
+
+          # get the APIG endpoint URL:
           APIG_URL=$(./node_modules/.bin/serverless info --aws-profile serverless --stage $SERVERLESS_STAGE | sed -nr 's#^.*(https://.+/dev)/png$#\1#p')
+          echo "Discovered APIG_URL: $APIG_URL"
 
           # CURL to some known good endpoints expecting 200:
           function TEST_HTTP ()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       # - https://www.serverless.com/framework/docs/providers/aws/guide/deploying#tips
       # github.run_id: A unique number for each run within a repository. This number does not change if you re-run the workflow run. https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
       # github format: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#format
-      SERVERLESS_STAGE: ${{ github.event_name == "pull_request" && format('pr{0}', github.job_id) || format('push{0}', github.job_id) }}
+      SERVERLESS_STAGE: ${{ github.event_name == 'pull_request' && format('pr{0}', github.job_id) || format('push{0}', github.job_id) }}
     steps:
       - uses: actions/checkout@v1
 


### PR DESCRIPTION
…ng issues running e2e tests concurrently

Effectively reverts 1041a22b6a2b8009edd54b33e4243fd01f47bfca since that causes merges into main to not deploy. Implements new mitigation for e2e tests using shared resource.

