### PR TITLE
fix: shorter name for basic example to avoid IAM role names hitting length limit for long stage names

### DIFF
--- a/examples/basic/serverless.yml
+++ b/examples/basic/serverless.yml
@@ -1,4 +1,4 @@
-service: static-file-handler-demo-proxy
+service: static-file-handler-demo
 
 plugins:
   - serverless-aws-static-file-handler/plugins/BinaryMediaTypes


### PR DESCRIPTION
this length limit was hit in e2e tests in push to main branch due to stage name length