### PR TITLE
Work with HTTP API v2

### DIFF
--- a/examples/basic/data-files/index.html
+++ b/examples/basic/data-files/index.html
@@ -37,11 +37,11 @@
 
   <script lang="javascript">
         /**
-         * Returns the root path/prefix that should be used. WILL include the trailing backslash. 
+         * Returns the root path/prefix that should be used. WILL include the trailing backslash.
          * NOTES:
          * In APIG V1 REST APIs the stage is the initial path by default (e.g. `/dev` or `/dev/`).
          * In APIG V2 HTTP APIs there is a default stage specified by default so there may not be one. We deploy this sample though to `/v2` for HTTP APIs so we're catching that or the stage here:
-         */ 
+         */
         function getPathPrefix() {
           // tldr; get the portion of the path up to the first / character. If there is no / character, get the whole thing:
           const len = window.location.pathname.indexOf("/", 1) != -1 ? window.location.pathname.indexOf("/", 1) : window.location.pathname.length

--- a/examples/basic/data-files/index.html
+++ b/examples/basic/data-files/index.html
@@ -36,19 +36,17 @@
   </div>
 
   <script lang="javascript">
-        function verifyRootPath() {
-          // I've wated time more than once trying to figure this out:
-          if (!window.location.href.endsWith("/")) {
-            let msg = document.createElement("span")
-            msg.innerText = "⛔️ The root path does not end with a backslash (/)! It probably should (and serverless-offline doesn't add it by defualt)."
-            let fixit = document.createElement("a")
-            fixit.href = window.location.href + "/"
-            fixit.innerText = "Fix it!"
-            document.querySelector("#banner").appendChild(msg)
-            document.querySelector("#banner").appendChild(fixit)
-          }
+        /**
+         * Returns the root path/prefix that should be used. WILL include the trailing backslash. 
+         * NOTES:
+         * In APIG V1 REST APIs the stage is the initial path by default (e.g. `/dev` or `/dev/`).
+         * In APIG V2 HTTP APIs there is a default stage specified by default so there may not be one. We deploy this sample though to `/v2` for HTTP APIs so we're catching that or the stage here:
+         */ 
+        function getPathPrefix() {
+          // tldr; get the portion of the path up to the first / character. If there is no / character, get the whole thing:
+          const len = window.location.pathname.indexOf("/", 1) != -1 ? window.location.pathname.indexOf("/", 1) : window.location.pathname.length
+          return window.location.pathname.substring(0, len) + "/"
         }
-        verifyRootPath()
         // this loads the various images/files:
         const validPaths = [
           { path: "binary/png.png", expectedStatus: [200] },
@@ -86,7 +84,7 @@
             let response
             let lastError
             try {
-              response = await fetch(test.path)
+              response = await fetch(getPathPrefix() + test.path)
               contentType = response.headers.get("Content-type") + `, ${response.status}: ${response.statusText}`
 
               if (!response.ok)

--- a/examples/basic/handler.js
+++ b/examples/basic/handler.js
@@ -9,9 +9,21 @@ module.exports.root = async (event, context) => {
   return fileHandler.get(event, context)
 }
 
+module.exports.v2_root = async (event, context) => {
+  event.rawPath = "index.html" // forcing a specific page for this handler; ignore requested path
+  return fileHandler.get(event, context)
+}
+
 module.exports.binary = async (event, context) => {
   if (!event.path.startsWith("/binary/")) {
-    throw new Error(`[404] Invalid filepath for this resource: ${fname}`)
+    throw new Error(`[404] Invalid filepath for this resource`)
+  }
+  return fileHandler.get(event, context)
+}
+
+module.exports.v2_binary = async (event, context) => {
+  if (!event.rawPath.startsWith("/v2/binary/")) {
+    throw new Error(`[404] Invalid filepath for this resource`)
   }
   return fileHandler.get(event, context)
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,7 +8,10 @@
     "deploy": "serverless deploy --aws-profile serverless",
     "destroy": "serverless remove --aws-profile serverless",
     "lint": "prettier --write \"./**/*.{js,md,yml,json,html}\"",
-    "reset": "rm -rfd ./node_modules/ && npm i && npm run deploy"
+    "reset": "rm -rfd ./node_modules/ && npm i && npm run deploy",
+    "//dev-link": "Useful for debugging but don't commit it in this way; use `npm run dev-unlink` before committing. NOTE: Not using `npm link` or `npm add ../..` because that creates a filesystem symlink and serverless.com freaks out when attempting a deploy with a symlinked dependency.",
+    "dev-link": "pushd . ; cd ../.. ; npm pack ; popd ; npm add ../../serverless-aws-static-file-handler-0.0.0.tgz",
+    "dev-unlink": "npm rm serverless-aws-static-file-handler ; npm add serverless-aws-static-file-handler@>=3.0.2-beta.1"
   },
   "devDependencies": {
     "serverless": "^2.52.1"

--- a/examples/basic/serverless.yml
+++ b/examples/basic/serverless.yml
@@ -29,3 +29,18 @@ functions:
       - http:
           path: /binary/{pathvar+}
           method: get
+
+  # API Gateway V2 Payload or HTTP API are below. As described at https://www.serverless.com/framework/docs/providers/aws/events/http-api
+  v2_html:
+    handler: handler.v2_root
+    events:
+      - httpApi:
+          path: /v2
+          method: get
+
+  v2_binary:
+    handler: handler.v2_binary
+    events:
+      - httpApi:
+          path: /v2/binary/{pathvar+}
+          method: get

--- a/src/StaticFileHandler.js
+++ b/src/StaticFileHandler.js
@@ -60,21 +60,21 @@ class StaticFileHandler {
       throw new Error("event object not specified.")
     }
 
-    if( event.rawPath ){
+    if (event.rawPath) {
       // convert the V2 API to look like v1 like rest of code expects
 
       // this matches validateLambdaProxyIntegration required props
-      event.resource   = event.requestContext.http.path;
-      event.path       = event.rawPath;
-      event.httpMethod = event.requestContext.http.method;
+      event.resource = event.requestContext.http.path
+      event.path = event.rawPath
+      event.httpMethod = event.requestContext.http.method
       // OK as is event.headers
-      event.multiValueHeaders               = event.headers;
-      event.queryStringParameters           = event.queryStringParamaters;
-      event.multiValueQueryStringParameters = event.queryStringParameters; // Not sure what old code does ?
+      event.multiValueHeaders = event.headers
+      event.queryStringParameters = event.queryStringParamaters
+      event.multiValueQueryStringParameters = event.queryStringParameters // Not sure what old code does ?
       // OK as is event.pathParameters
-      event.stageVariables = event.requestContext.stage; // Not sure we ever pass these ?
+      event.stageVariables = event.requestContext.stage // Not sure we ever pass these ?
       // OK as is event.requestContext
-      event.body = '' // It is a GET, there never is one ?
+      event.body = "" // It is a GET, there never is one ?
       // OK as is event.isBase64Encoded
     }
 

--- a/src/StaticFileHandler.js
+++ b/src/StaticFileHandler.js
@@ -59,6 +59,25 @@ class StaticFileHandler {
     if (!event) {
       throw new Error("event object not specified.")
     }
+
+    if( event.rawPath ){
+      // convert the V2 API to look like v1 like rest of code expects
+
+      // this matches validateLambdaProxyIntegration required props
+      event.resource   = event.requestContext.http.path;
+      event.path       = event.rawPath;
+      event.httpMethod = event.requestContext.http.method;
+      // OK as is event.headers
+      event.multiValueHeaders               = event.headers;
+      event.queryStringParameters           = event.queryStringParamaters;
+      event.multiValueQueryStringParameters = event.queryStringParameters; // Not sure what old code does ?
+      // OK as is event.pathParameters
+      event.stageVariables = event.requestContext.stage; // Not sure we ever pass these ?
+      // OK as is event.requestContext
+      event.body = '' // It is a GET, there never is one ?
+      // OK as is event.isBase64Encoded
+    }
+
     if (!event.path) {
       throw new Error("Empty path.")
     }

--- a/src/StaticFileHandler.js
+++ b/src/StaticFileHandler.js
@@ -5,7 +5,7 @@ const mimetypes = require("mime-types")
 const Mustache = require("mustache")
 const path = require("path")
 const util = require("util")
-
+const _ = require("lodash")
 const readFileAsync = util.promisify(fs.readFile)
 const accessAsync = util.promisify(fs.access)
 
@@ -239,32 +239,44 @@ class StaticFileHandler {
    * Rejects if the specified event is not Lambda Proxy integration
    */
   static async validateLambdaProxyIntegration(event) {
-    // From https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
-    const expectedProps = [
-      "resource",
-      "path",
-      "httpMethod",
-      "headers",
-      "multiValueHeaders",
-      "queryStringParameters",
-      "multiValueQueryStringParameters",
-      "pathParameters",
-      "stageVariables",
-      "requestContext",
-      "body",
-      "isBase64Encoded",
-    ]
-    const missingProps = expectedProps.filter(
-      (propName) => !(propName in event)
-    )
-    // We're using serverless-offline which doesn't provide the `isBase64Encoded` prop, but does add the isOffline. Fixes issue #10: https://github.com/activescott/serverless-aws-static-file-handler/issues/10
-    const isServerlessOfflineEnvironment =
-      missingProps.length === 1 &&
-      missingProps[0] === "isBase64Encoded" &&
-      "isOffline" in event
-    if (missingProps.length > 0 && !isServerlessOfflineEnvironment) {
+    /* 
+    There are two different event schemas in API Gateway + Lambda Proxy APIs. One is known as "REST API" or the old V1 API and the newer one is the V2 or "HTTP API". 
+    Each are described at https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html#services-apigateway-apitypes
+    You can see examples of each at https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+    TLDR: 
+    - V2 has a { version: "2.0" } field and { requestContext.http.method: "..." }  field.
+    - V1 has a { version: "1.0" } field and { requestContext.httpMethod: "..." }  field.
+    To set each up in serverless.com:
+    - V1: https://www.serverless.com/framework/docs/providers/aws/events/apigateway
+    - V2: https://www.serverless.com/framework/docs/providers/aws/events/http-api
+    */
+    function isV2ProxyAPI(evt) {
+      return (
+        evt.version === "2.0" &&
+        typeof _.get(evt, "requestContext.http.method") === "string"
+      )
+    }
+    function isV1ProxyAPI(evt) {
+      return (
+        // docs say there is a .version but there isn't!
+        // evt.version === "1.0" &&
+        typeof _.get(evt, "requestContext.httpMethod") === "string"
+      )
+    }
+    // serverless-offline doesn't provide the `isBase64Encoded` prop, but does add the isOffline. Fixes issue #10: https://github.com/activescott/serverless-aws-static-file-handler/issues/10
+    const isServerlessOfflineEnvironment = "isOffline" in event
+    if (!isV1ProxyAPI(event) && !isV2ProxyAPI(event)) {
+      const logProps = [
+        "version",
+        "requestContext.httpMethod",
+        "requestContext.http.method",
+      ]
+      const addendum = logProps
+        .map((propName) => `event.${propName} was '${_.get(event, propName)}'`)
+        .join(" ")
       throw new Error(
-        `API Gateway method does not appear to be setup for Lambda Proxy Integration. Please confirm that \`integration\` property of the http event is not specified or set to \`integration: proxy\`. Missing lambda proxy property was ${missingProps[0]}`
+        "API Gateway method does not appear to be setup for Lambda Proxy Integration. Please confirm that `integration` property of the http event is not specified or set to `integration: proxy`." +
+          addendum
       )
     }
   }

--- a/src/test/StaticFileHandler.js
+++ b/src/test/StaticFileHandler.js
@@ -16,13 +16,15 @@ function mockEvent(event) {
   return {
     resource: null,
     httpMethod: "GET",
+    requestContext: {
+      httpMethod: "GET",
+    },
     headers: {},
     multiValueHeaders: {},
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     pathParameters: null,
     stageVariables: null,
-    requestContext: {},
     body: null,
     isBase64Encoded: false,
     ...event,

--- a/src/test/StaticFileHandler.js
+++ b/src/test/StaticFileHandler.js
@@ -31,6 +31,23 @@ function mockEvent(event) {
   }
 }
 
+// https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+function mockEventV2(path,event) {
+  return {
+    "version": "2.0",
+    "routeKey": "$default",
+    "rawPath": path,
+    "requestContext":{
+      "http": {
+        "method": "GET",
+        "path": path
+      }
+    },
+    ...event,
+  }
+}
+
+
 describe("StaticFileHandler", function () {
   describe("constructor", function () {
     it("should not allow empty arg", function () {
@@ -344,6 +361,35 @@ describe("StaticFileHandler", function () {
           return response
         })
       })
+    })
+  })
+
+  describe("get (httpApi v2)",function(){
+    it("should return index.html", function () {
+      const event = mockEventV2( "index.html" )
+      let h = new StaticFileHandler(STATIC_FILES_PATH)
+      return h.get(event, null).then((response) => {
+        expect(response).to.have.property("statusCode", 200)
+        expect(response)
+          .to.have.property("body")
+          .to.match(/^<!DOCTYPE html>/)
+        return response
+      })
+    })
+    it("should support path parameters", function () {
+      const event = mockEventV2(
+        "/binary/vendor/output.css.map",
+        {pathParameters: { pathvar: "vendor/output.css.map" }}
+      )
+      let h = new StaticFileHandler(STATIC_FILES_PATH)
+      const response = h.get(event, null)
+      expect(response)
+        .to.eventually.have.ownProperty("statusCode")
+        .that.equals(200)
+      return expect(response)
+        .to.eventually.haveOwnProperty("body")
+        .that.is.a("string")
+        .and.has.length(107)
     })
   })
 })

--- a/src/test/StaticFileHandler.js
+++ b/src/test/StaticFileHandler.js
@@ -32,21 +32,20 @@ function mockEvent(event) {
 }
 
 // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
-function mockEventV2(path,event) {
+function mockEventV2(path, event) {
   return {
-    "version": "2.0",
-    "routeKey": "$default",
-    "rawPath": path,
-    "requestContext":{
-      "http": {
-        "method": "GET",
-        "path": path
-      }
+    version: "2.0",
+    routeKey: "$default",
+    rawPath: path,
+    requestContext: {
+      http: {
+        method: "GET",
+        path: path,
+      },
     },
     ...event,
   }
 }
-
 
 describe("StaticFileHandler", function () {
   describe("constructor", function () {
@@ -364,9 +363,9 @@ describe("StaticFileHandler", function () {
     })
   })
 
-  describe("get (httpApi v2)",function(){
+  describe("get (httpApi v2)", function () {
     it("should return index.html", function () {
-      const event = mockEventV2( "index.html" )
+      const event = mockEventV2("index.html")
       let h = new StaticFileHandler(STATIC_FILES_PATH)
       return h.get(event, null).then((response) => {
         expect(response).to.have.property("statusCode", 200)
@@ -377,10 +376,9 @@ describe("StaticFileHandler", function () {
       })
     })
     it("should support path parameters", function () {
-      const event = mockEventV2(
-        "/binary/vendor/output.css.map",
-        {pathParameters: { pathvar: "vendor/output.css.map" }}
-      )
+      const event = mockEventV2("/binary/vendor/output.css.map", {
+        pathParameters: { pathvar: "vendor/output.css.map" },
+      })
       let h = new StaticFileHandler(STATIC_FILES_PATH)
       const response = h.get(event, null)
       expect(response)

--- a/src/test/e2e.js
+++ b/src/test/e2e.js
@@ -9,7 +9,7 @@ const { spawnSync } = require("child_process")
 
 describe("e2e", function () {
   // npm install & serverless loading a project is pretty slow (apparently damn slow on node8: https://travis-ci.org/activescott/serverless-aws-static-file-handler/jobs/632405805?utm_medium=notification&utm_source=github_status)
-  this.timeout(25000)
+  this.timeout(60000)
 
   it("should load plugin", function () {
     // does a simple load of a plugin per https://github.com/activescott/serverless-aws-static-file-handler/issues/32


### PR DESCRIPTION
## What did you implement:

Closes #47 
## How did you implement it:

Copy v2 props to what seems to be right place in the old v1 event

## How can we verify it:

```
service: name-here

provider:
  name: aws
  runtime: nodejs12.x

  httpApi:
    payload: '2.0'
    cors: true

functions:
  dist:
    handler: handler.dist
    events:
      - httpApi:
          path: /dist/{file_name}
          method: get
```
```
const path = require('path');

const StaticFileHandler = require('serverless-aws-static-file-handler')
const clientFilesPath = path.join(__dirname,"./dist/")
const fileHandler = new StaticFileHandler(clientFilesPath);

module.exports.dist = async (event,context) => {
  if (!event.rawPath.startsWith("/dist/")) {
    throw new Error(`[404] Invalid filepath for this resource: ${event.rawPath}`)
  }

  return fileHandler.get(event, context);
}
```

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [ ] All tests pass on our CI Server: https://travis-ci.org/activescott/serverless-aws-static-file-handler
