### PR TITLE
build: change local dev package version to 0.0.0 to support e2e tests in build workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "serverless-aws-static-file-handler",
   "description": "Easily serve static files with the Serverless Framework on AWS Lambda.",
   "homepage": "https://github.com/activescott/serverless-aws-static-file-handler#readme",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "main": "src/StaticFileHandler.js",
   "author": {
     "name": "Scott Willeke",


### PR DESCRIPTION
The tests in the pipeline at https://github.com/activescott/serverless-aws-static-file-handler/blob/22be6b7f422ca2ff0ebb6476f60759617e391325/.github/workflows/build.yml#L123 expect that generated package to have a version number of 0.0.0. I missed this testing the last PR since I ran it all locally since the github actions pipeline doesn't allow secrets from forks (and I haven't figured out how to permit that yet).