### PR TITLE
chore(build): wait longer for serverless offline to start

### DIFF
--- a/test-files/scripts/test-local-e2e.sh
+++ b/test-files/scripts/test-local-e2e.sh
@@ -31,15 +31,18 @@ npm install -s
 echo "Running npm install completed."
 
 # run severless-offline in background:
-
 start_serverless_offline() {
   echo "starting serverless-offline in background..."
   ./node_modules/.bin/serverless offline &
 
   # wait on serverless-offline to start
-  echo "waiting on serverless-offline for 5s..."
-  sleep 5
-  echo "waiting on serverless-offline for 5s complete."
+  SECS=10
+  while [ $SECS -gt 0 ]; do
+    printf "waiting for $SECS seconds for serverless-offline to start serving...\n"
+    sleep 1
+    SECS=`expr $SECS - 1`
+  done
+  printf "waiting for seconds for serverless-offline complete. Continuing with test\n"
 }
 
 start_serverless_offline


### PR DESCRIPTION
serverless-offline failed to come up in https://github.com/activescott/serverless-aws-static-file-handler/actions/runs/2811290280 although it succeeded in the PR before merging