### PR TITLE
chore: setup github actions to only run a single build at a time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches: [main]
 
+# Allow one concurrent build & deployment
+concurrency:
+  group: "build"
+
 jobs:
   unit_tests:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
concurrent builds are a mess with dependabot because every single one has to rebuild after any PR is merged
