### PR TITLE
build: verifying that the correct ref is checked out in a target branch after merge

### DIFF
--- a/.github/workflows/debug-workflow.yml
+++ b/.github/workflows/debug-workflow.yml
@@ -18,6 +18,8 @@ jobs:
         id: set_ref
         env:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
+        # The intent here is to checkout the PR's branch/commit head when it is an open PR
+        # ...but checkout the target branch's head commit when it is a PR being merged or a commit directly to the branch.
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.event.pull_request.merged }}" == "false" ]]; then
             echo "REF=${GITHUB_HEAD_REF}" >> $GITHUB_ENV


### PR DESCRIPTION
Doing this by modifying a file that already exists in the base/target branch so that we can confirm the modified version is checked out rather than the original one.
