### PR TITLE
chore: update example serverless-offline v12->v13; remove CI testing on node v14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          # NOTE: in v13.0, serverless-offline removed support for node v14: https://github.com/dherault/serverless-offline/releases/tag/v13.0.0
+          node-version: 18
 
       - name: build plugin locally
         run: |

--- a/examples/serverless-offline/package.json
+++ b/examples/serverless-offline/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "serverless": "^3.1.1",
-    "serverless-offline": "^12.0.3"
+    "serverless-offline": "^13.2.0"
   },
   "dependencies": {
     "serverless-aws-static-file-handler": ">=3.0.2-beta.1"


### PR DESCRIPTION
Dependabot seemed to have trouble with this but the same tests all passed locally for me 🤷 