### PR TITLE
chore: revert serverless v4 bump and pin to v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       day: "saturday"
     allow:
       - dependency-type: "production"
+    ignore:
+      - dependency-name: "serverless"
+        update-types: ["version-update:semver-major"]
     commit-message:
       # for production deps, prefix commit messages with "fix" (trigger a patch release)
       prefix: "fix"
@@ -28,6 +31,9 @@ updates:
     allow:
       # Allow only direct updates for all packages
       - dependency-type: "direct"
+    ignore:
+      - dependency-name: "serverless"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/test-files/webpack-project"
@@ -41,6 +47,9 @@ updates:
     allow:
       # Allow only direct updates for all packages
       - dependency-type: "direct"
+    ignore:
+      - dependency-name: "serverless"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/examples/basic"
@@ -54,6 +63,9 @@ updates:
     allow:
       # Allow only direct updates for all packages
       - dependency-type: "direct"
+    ignore:
+      - dependency-name: "serverless"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/examples/serverless-offline"
@@ -67,3 +79,6 @@ updates:
     allow:
       # Allow only direct updates for all packages
       - dependency-type: "direct"
+    ignore:
+      - dependency-name: "serverless"
+        update-types: ["version-update:semver-major"]

--- a/test-files/basic-project/package.json
+++ b/test-files/basic-project/package.json
@@ -8,7 +8,7 @@
     "destroy": "serverless remove"
   },
   "devDependencies": {
-    "serverless": "^4"
+    "serverless": "^3"
   },
   "dependencies": {
     "serverless-aws-static-file-handler": "file:../../serverless-aws-static-file-handler-0.0.0.tgz"


### PR DESCRIPTION
## Summary
- Reverts the serverless `^4` bump from PR #395 in `test-files/basic-project` back to `^3.40.0`
- Adds `ignore` rules for `serverless` major version updates across all 5 dependabot entries to prevent future v4 PRs

## Test plan
- [x] All existing tests pass
- [ ] Verify dependabot no longer proposes serverless v4 bumps on next monthly run