### PR TITLE
chore: revert serverless v4 bumps and strengthen dependabot pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       - dependency-type: "production"
     ignore:
       - dependency-name: "serverless"
-        update-types: ["version-update:semver-major"]
+        versions: [">=4"]
     commit-message:
       # for production deps, prefix commit messages with "fix" (trigger a patch release)
       prefix: "fix"
@@ -33,7 +33,7 @@ updates:
       - dependency-type: "direct"
     ignore:
       - dependency-name: "serverless"
-        update-types: ["version-update:semver-major"]
+        versions: [">=4"]
 
   - package-ecosystem: "npm"
     directory: "/test-files/webpack-project"
@@ -49,7 +49,7 @@ updates:
       - dependency-type: "direct"
     ignore:
       - dependency-name: "serverless"
-        update-types: ["version-update:semver-major"]
+        versions: [">=4"]
 
   - package-ecosystem: "npm"
     directory: "/examples/basic"
@@ -65,7 +65,7 @@ updates:
       - dependency-type: "direct"
     ignore:
       - dependency-name: "serverless"
-        update-types: ["version-update:semver-major"]
+        versions: [">=4"]
 
   - package-ecosystem: "npm"
     directory: "/examples/serverless-offline"
@@ -81,4 +81,7 @@ updates:
       - dependency-type: "direct"
     ignore:
       - dependency-name: "serverless"
-        update-types: ["version-update:semver-major"]
+        versions: [">=4"]
+      # serverless-offline v14+ requires Serverless Framework v4
+      - dependency-name: "serverless-offline"
+        versions: [">=14"]

--- a/examples/serverless-offline/package.json
+++ b/examples/serverless-offline/package.json
@@ -13,7 +13,7 @@
     "dev-unlink": "npm i"
   },
   "devDependencies": {
-    "serverless": "^4",
+    "serverless": "^3",
     "serverless-offline": "^13.9.0"
   },
   "dependencies": {

--- a/examples/serverless-offline/package.json
+++ b/examples/serverless-offline/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "serverless": "^4",
-    "serverless-offline": "^14.5.0"
+    "serverless-offline": "^13.9.0"
   },
   "dependencies": {
     "serverless-aws-static-file-handler": ">=3.0.2-beta.1"

--- a/test-files/basic-project/package.json
+++ b/test-files/basic-project/package.json
@@ -8,7 +8,7 @@
     "destroy": "serverless remove"
   },
   "devDependencies": {
-    "serverless": "^4"
+    "serverless": "^3"
   },
   "dependencies": {
     "serverless-aws-static-file-handler": "file:../../serverless-aws-static-file-handler-0.0.0.tgz"


### PR DESCRIPTION
## Summary

Reverts three dependabot PRs that pulled Serverless Framework v4 (and its transitively-required serverless-offline v14) into the repo. Per the README, this project pins to Serverless v3. Also strengthens the dependabot ignore rules so this can't happen again.

### Reverted commits

- \`e78e0db\` — bump serverless-offline 13.9.0 → 14.5.0 in \`/examples/serverless-offline\` (#394). serverless-offline v14+ requires Serverless v4.
- \`60c47ed\` — bump serverless ^3 → ^4 in \`/examples/serverless-offline\` (#409)
- \`8b0c26c\` — bump serverless ^3 → ^4 in \`/test-files/basic-project\` (#403)

All three are reverted as separate \`chore:\` commits so no npm release is triggered.

### Dependabot config

The previous pin used \`update-types: ["version-update:semver-major"]\`, but #409 was merged a full month after that pin was added — the rule clearly was not honored. Switch to an explicit \`versions: [">=4"]\` range, and also block \`serverless-offline\` ≥14 in \`/examples/serverless-offline\`.

## Test plan

- [x] \`npm test\` passes locally with all 39 tests
- [x] All commits signed
- [ ] CI checks pass on this PR

## Note (out of scope)

\`test-files/webpack-project/package.json\` has had the contradictory pair \`"serverless": "^3.35.2"\` + \`"serverless-offline": "^14.5.0"\` since #385 in March — predates the v4 bumps so not reverted here. Worth a separate look if that subproject is meant to actually run.