### PR TITLE
chore(ci): use Node 24 in publish job for npm 11 OIDC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,11 +175,11 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # Node 24 ships with npm 11, which is required for npm OIDC trusted publishing (>=11.5.1).
+          # Node 22's bundled npm 10 forced a `npm install -g npm@latest` self-upgrade step,
+          # which broke after a regression in Node 22.22.2's toolcache npm (npm/cli#9151).
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: publish to npm
         env:


### PR DESCRIPTION
## Summary

- Bump the `publish_package` job from Node 22 → Node 24 and drop the brittle `npm install -g npm@latest` self-upgrade step.
- Node 24 ships with npm 11, which already meets the npm OIDC trusted-publishing minimum (>=11.5.1), so we no longer need to upgrade npm in-place at publish time.

## Why

The publish step on `main` (and PR #412 merge) failed with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

This is a known regression in the bundled npm 10.9.7 inside Node 22.22.2's GitHub Actions toolcache — the bundled npm cannot bootstrap itself to upgrade. Refs:

- npm/cli#9151
- actions/runner-images#13883

The previous workaround (`npm install -g npm@latest`) existed only to satisfy npm's >=11.5.1 OIDC requirement on Node 22's npm 10. Switching the publish job to Node 24 makes that step unnecessary.

## Scope

Only `.github/workflows/build.yml` (the `publish_package` job) is changed.

- `engines.node` in `package.json` is unchanged (`>=20`).
- No `dependencies` / `devDependencies` / `peerDependencies` changes.
- The unit_tests matrix still runs on Node 20 and 22.
- The published tarball is unaffected.

## Test plan

- [ ] `unit_tests (20)` passes
- [ ] `unit_tests (22)` passes
- [ ] `e2e_tests` passes
- [ ] `publish_package` is skipped on PR (it only runs on push to `main`/`beta`/`next`)
- [ ] After merge to `main`, `publish_package` runs successfully on Node 24 and `npx semantic-release@25` completes (no release expected — `chore(ci):` prefix should not trigger a publish, only verify the OIDC/npm path no longer crashes)